### PR TITLE
Fix barcode checksum validation for letter prefix

### DIFF
--- a/protocol/tagtinker_proto.c
+++ b/protocol/tagtinker_proto.c
@@ -286,8 +286,8 @@ void tagtinker_free_image_payload(TagTinkerImagePayload* payload) {
 
 bool tagtinker_is_barcode_valid(const char* barcode) {
     if(!barcode || strlen(barcode) != 17) return false;
-    int cs = 0; for(int i = 0; i < 16; i++) cs += (int)(barcode[i] - '0');
-    return ((cs % 10) == (barcode[16] - '0'));
+    int cs = 0; for(int i = 0; i < 17; i++) cs += (int)(barcode[i] - '0');
+    return (cs % 10) == 0;
 }
 
 size_t tagtinker_make_addressed_frame(uint8_t* buf, const uint8_t plid[4], const uint8_t* payload, size_t len) {


### PR DESCRIPTION
 ## Summary
  The barcode validator in `tagtinker_is_barcode_valid` rejects valid Pricer barcodes that start with a letter prefix
  (e.g. `A4120365539013704`).

  ## Root cause
  The check used `sum(barcode[0..15]) % 10 == barcode[16] - '0'`, which doesn't match the Pricer checksum scheme. Pricer
   validates the full 17-character code as `sum(all chars) % 10 == 0`, where the letter prefix contributes by its ASCII
  offset from `'0'` (e.g. `A` = 17).

  Example — `A4120365539013704`:
  - old formula: `(17+4+1+2+0+3+6+5+5+3+9+0+1+3+7+0) % 10 = 6 ≠ 4` → rejected
  - correct: `(sum + 4) % 10 = 70 % 10 = 0` → valid

  ## Fix
  Sum all 17 characters and require the total to be divisible by 10.