### PR TITLE
Add ufbt build workflow for Unleashed firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: "FAP: Build for Unleashed"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ufbt-build-action:
+    runs-on: ubuntu-latest
+    name: "ufbt: Build for Unleashed"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build with ufbt
+        uses: flipperdevices/flipperzero-ufbt-action@v0.1
+        id: build-app
+        with:
+          sdk-index-url: https://up.unleashedflip.com/directory.json
+          sdk-channel: release
+
+      - name: Upload app artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: TagTinker-unleashed
+          path: ${{ steps.build-app.outputs.fap-artifacts }}


### PR DESCRIPTION
Fügt .github/workflows/build.yml hinzu, um die TagTinker-FAP
gegen das Unleashed-SDK zu bauen.

Nutzt die offizielle flipperzero-ufbt-action mit
sdk-index-url auf up.unleashedflip.com. Läuft manuell über
workflow_dispatch und lädt die fertige .fap als Artifact hoch.